### PR TITLE
random changes to show coverage diff

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -125,6 +125,10 @@ Segment = namedtuple("Segment", "uri duration title key discontinuity ad byteran
 LOW_LATENCY_MAX_LIVE_EDGE = 2
 
 
+def something_not_test_and_covered():
+    pass
+
+
 class TwitchM3U8Parser(M3U8Parser):
     def parse_extinf(self, value):
         duration, title = super(TwitchM3U8Parser, self).parse_extinf(value)
@@ -136,7 +140,8 @@ class TwitchM3U8Parser(M3U8Parser):
     def parse_tag_ext_x_twitch_prefetch(self, value):
         segments = self.m3u8.segments
         if segments:
-            segments.append(segments[-1]._replace(uri=self.uri(value), prefetch=True))
+            clone = segments[-1]._replace(uri=self.uri(value), prefetch=True)
+            segments.append(clone)
 
     def get_segment(self, uri):
         byterange = self.state.pop("byterange", None)

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -20,6 +20,10 @@ log = logging.getLogger(__name__)
 Sequence = namedtuple("Sequence", "num segment")
 
 
+def something_not_test_and_covered():
+    pass
+
+
 def num_to_iv(n):
     return struct.pack(">8xq", n)
 
@@ -218,10 +222,12 @@ class HLSStreamWorker(SegmentedStreamWorker):
 
         self.reader.buffer.wait_free()
         log.debug("Reloading playlist")
-        res = self.session.http.get(self.stream.url,
-                                    exception=StreamError,
-                                    retries=self.playlist_reload_retries,
-                                    **self.reader.request_params)
+        res = self.session.http.get(
+            self.stream.url,
+            exception=StreamError,
+            retries=self.playlist_reload_retries,
+            **self.reader.request_params
+        )
         try:
             playlist = self._reload_playlist(res.text, res.url)
         except ValueError as err:


### PR DESCRIPTION
Testing codecov PR comment change...

uses `ci/coverage/improvements-2020-09` as the base of the PR, not `master`